### PR TITLE
FB rough auth fix

### DIFF
--- a/application/configs/appkeys_example.ini
+++ b/application/configs/appkeys_example.ini
@@ -6,12 +6,12 @@
 
 facebook.appid = YOUR_FACEBOOK_APPID
 facebook.secret = YOUR_FACEBOOK_SECRET
-facebook.redirecturi = http://url.of.your.app/
+facebook.redirecturi = http://url.of.your.app/user/login/
 facebook.scope = 'email'
 
 twitter.appid = YOUR_TWITTER_APPID
 twitter.secret = YOUR_TWITTER_SECRET
-twitter.redirecturi = http://url.of.your.app/
+twitter.redirecturi = http://url.of.your.app/user/login/
 
 ; Try to fetch these parameters from the providers
 openid.tofetch.email = true

--- a/application/views/scripts/index/index.phtml
+++ b/application/views/scripts/index/index.phtml
@@ -20,6 +20,7 @@
 
                             <?php
                             foreach ($this->identity['properties'] as $p => $v) {
+                               if (is_array($v)) {$v=$v[0]->name;}
                                echo $this->partial('_partial/properties.phtml', array($p, $v) );
                             }
                             ?>


### PR DESCRIPTION
- Extended the example appkeys.ini to hint the required landing url for facebook and twitter auth
- Fix for FB authentication returning arrays/objects in $v on multiple user selections (ubterests, etc)

Best,

Mike
